### PR TITLE
Modify USBPrinterAdapter.kt openConnection default value

### DIFF
--- a/android/src/main/kotlin/app/mylekha/client/flutter_usb_printer/adapter/USBPrinterAdapter.kt
+++ b/android/src/main/kotlin/app/mylekha/client/flutter_usb_printer/adapter/USBPrinterAdapter.kt
@@ -161,7 +161,7 @@ class USBPrinterAdapter {
                 }
             }
         }
-        return true
+        return false
     }
 
     fun printText(text: String): Boolean {


### PR DESCRIPTION
Modify USBPrinterAdapter.kt openConnection default value from true to false. 
For when USBDevice is not a printer, then printText time will NPE issue.