### PR TITLE
Null Exception Handling

### DIFF
--- a/.idea/libraries/Flutter_Plugins.xml
+++ b/.idea/libraries/Flutter_Plugins.xml
@@ -1,8 +1,6 @@
 <component name="libraryTable">
   <library name="Flutter Plugins" type="FlutterPluginsLibraryType">
-    <CLASSES>
-      <root url="file://$PROJECT_DIR$" />
-    </CLASSES>
+    <CLASSES />
     <JAVADOC />
     <SOURCES />
   </library>

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip

--- a/android/src/main/kotlin/app/mylekha/client/flutter_usb_printer/FlutterUsbPrinterPlugin.kt
+++ b/android/src/main/kotlin/app/mylekha/client/flutter_usb_printer/FlutterUsbPrinterPlugin.kt
@@ -28,7 +28,7 @@ class FlutterUsbPrinterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
     channel = MethodChannel(flutterPluginBinding.binaryMessenger, "flutter_usb_printer")
     channel.setMethodCallHandler(this)
     context = flutterPluginBinding.getApplicationContext()
-    adapter = USBPrinterAdapter()
+    adapter = USBPrinterAdapter.getInstance()
   }
 
   override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
@@ -117,6 +117,7 @@ class FlutterUsbPrinterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
 
   override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
     channel.setMethodCallHandler(null)
+    USBPrinterAdapter.dispose()
   }
 
   override fun onAttachedToActivity(binding: ActivityPluginBinding) {

--- a/android/src/main/kotlin/app/mylekha/client/flutter_usb_printer/FlutterUsbPrinterPlugin.kt
+++ b/android/src/main/kotlin/app/mylekha/client/flutter_usb_printer/FlutterUsbPrinterPlugin.kt
@@ -13,8 +13,6 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 
-
-
 /** FlutterUsbPrinterPlugin */
 class FlutterUsbPrinterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
   private var adapter: USBPrinterAdapter? = null
@@ -30,7 +28,7 @@ class FlutterUsbPrinterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
     channel = MethodChannel(flutterPluginBinding.binaryMessenger, "flutter_usb_printer")
     channel.setMethodCallHandler(this)
     context = flutterPluginBinding.getApplicationContext()
-    adapter = USBPrinterAdapter().getInstance()
+    adapter = USBPrinterAdapter()
   }
 
   override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
@@ -65,7 +63,6 @@ class FlutterUsbPrinterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
   }
 
   private fun getUSBDeviceList(result: Result) {
-
     val usbDevices = adapter!!.getDeviceList()
     val list = ArrayList<HashMap<String, String?>>()
     for (usbDevice in usbDevices) {
@@ -81,11 +78,11 @@ class FlutterUsbPrinterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
       }else{
         deviceMap["productName"] = "unknown";
       }
-      deviceMap["deviceId"] = Integer.toString(usbDevice.deviceId)
-      deviceMap["vendorId"] = Integer.toString(usbDevice.vendorId)
-      deviceMap["productId"] = Integer.toString(usbDevice.productId)
+      deviceMap["deviceId"] = usbDevice.deviceId.toString()
+      deviceMap["vendorId"] = usbDevice.vendorId.toString()
+      deviceMap["productId"] = usbDevice.productId.toString()
       list.add(deviceMap)
-      print("usbDevice ${usbDevice}");
+      print("usbDevice $usbDevice");
     }
     result.success(list)
   }

--- a/android/src/main/kotlin/app/mylekha/client/flutter_usb_printer/adapter/USBPrinterAdapter.kt
+++ b/android/src/main/kotlin/app/mylekha/client/flutter_usb_printer/adapter/USBPrinterAdapter.kt
@@ -1,5 +1,6 @@
 package app.mylekha.client.flutter_usb_printer.adapter
 
+import android.annotation.SuppressLint
 import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
@@ -14,12 +15,27 @@ import java.nio.charset.Charset
 import java.util.*
 
 
-class USBPrinterAdapter {
+class USBPrinterAdapter private constructor(){
     companion object {
         private const val TAG = "Flutter USB Printer"
 
         private const val ACTION_USB_PERMISSION =
             "app.mylekha.client.flutter_usb_printer.USB_PERMISSION"
+
+
+        @SuppressLint("StaticFieldLeak")
+        private var mInstance: USBPrinterAdapter? = null
+
+        fun getInstance(): USBPrinterAdapter {
+            if (mInstance == null) {
+                mInstance = USBPrinterAdapter()
+            }
+            return mInstance!!
+        }
+
+        fun dispose() {
+            mInstance = null
+        }
     }
 
     private var mContext: Context? = null


### PR DESCRIPTION
# Changes

## 1. Changed `USBPrinterAdapter` to singleton class.
Previously, `USBPrinterAdapter().getInstance()` worked same as constructor instantiating.
Changed `getInstance` to static method and disposed the static instance on `onDetachedFromEngine`

***

## 2. `mUsbDeviceReceiver` receiver always receives null for `usbDevice`
Checked in Android 12 & 13, the intent extra for `UsbManager.EXTRA_DEVICE` is always null.  
So, add the `vendorId` and `productId` to pendingIntent while requesting permissions.
If  `UsbManager.EXTRA_DEVICE` is null, then try to init usb device with `vendorId` and `productId`.

***

## 3. Moved `pendingIntent` from class scope to local scope
Since pending intent is only required when requesting permission, moved variable to local scope