### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'app.mylekha.client.flutter_usb_printer'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.5.20'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
Updated kotlin version to latest version.  Without this new version of kotlin, the library breaks in the recent version of flutter